### PR TITLE
Wait for close confirmation

### DIFF
--- a/src/spectator_mode_client.rs
+++ b/src/spectator_mode_client.rs
@@ -93,6 +93,7 @@ impl Sink<Bytes> for SpectatorModeClient {
 }
 
 pub async fn initiate_connection(address: &str) -> (SpectatorModeClient, impl std::future::Future<Output = Result<(), Error>>) {
+    tracing::info!("Connecting to SpectatorMode...");
     let url = Url::parse(address).unwrap();
     let mut socket_config = SocketConfig::default();
     socket_config.timeout = Duration::from_secs(15);


### PR DESCRIPTION
Sometimes, closing swb with Ctrl + C will show a graceful exit, and yet in SpectatorMode it will act as if the bridge disconnected unexpectedly and is awaiting reconnect. It turns out this originates from the close frame not being received, by the backend, which in turn originates from swb closing before the close frame is actually sent. This all comes back to using `future::select`, which will not wait for SpectatorModeClient to exit gracefully in the case of DolphinConnection finishing first. The SM client is closed, but awaiting this only awaits the frame to be sent; `sm_client_future` must be properly awaited to ensure the connection was actually closed gracefully.

The solution is that the sink closing will mean the forward future resolves, meaning we can sequentially await that future, and then `sm_client_future`, ensuring each has gracefully closed before exiting the program.

To extend this logic cleanup, some refactoring is done to the main method as the final commit of the PR.

### Note: one consequence

While this PR significantly improves the logic flow, the one unintended consequence is that in the event of `sm_client_future` finishing early, such as on max connection retries reached, it will take the attempted sending of a packet to realize that the sink was closed. Before, if this happened between games, the client would exit immediately due to `future::select`, but now it will exit as soon as the next game starts.

While this is not as ideal, I will say it's ok for 2 reasons:
1. One would imagine that the probability of being in a game vs out of a game when a randomly timed fatal connection error happens would favor being in a game anyways, if you are doing a continuous session. 
2. This is already a go-wrong case; this does not change expected behavior, and can be re-mitigated in other ways that do not involve messing with the go-right case, such as what the previous implementation was doing (i.e. swb-level heartbeats could be implemented if desired, since ezsockets heartbeats don't currently catch this case).