### PR TITLE
Interrupt Slippi stream if SpectatorMode connection closes first

### DIFF
--- a/src/dolphin_connection.rs
+++ b/src/dolphin_connection.rs
@@ -83,6 +83,7 @@ impl DolphinConnection {
     }
 
     pub fn initiate_disconnect(&self, peer_id: enet::PeerID) {
+        tracing::info!("Disconnecting from Slippi...");
         let mut host = self.host_cell.borrow_mut();
         let peer = host.peer_mut(peer_id);
         peer.disconnect(1337);

--- a/src/spectator_mode_client.rs
+++ b/src/spectator_mode_client.rs
@@ -64,8 +64,13 @@ impl ezsockets::ClientExt for MyClient {
         Ok(())
     }
 
+    // async fn on_close(&mut self, _close_frame: std::option::Option<ezsockets::CloseFrame>) -> Result<ClientCloseMode, Error> {
+    //     Ok(ClientCloseMode::Close)
+    // }
+
     async fn on_disconnect(&mut self) -> Result<ClientCloseMode, Error> {
         tracing::info!("Reconnecting to SpectatorMode...");
+        // Ok(ClientCloseMode::Close)
         Ok(ClientCloseMode::Reconnect)
     }
 }
@@ -87,7 +92,12 @@ impl Sink<Bytes> for SpectatorModeClient {
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.ws_client.close(None)?;
+        tracing::info!("Disconnecting from SpectatorMode...");
+
+        if let Err(SendError(..)) = self.ws_client.close(None) {
+            tracing::debug!("SpectatorMode connection is already closed.");
+        }
+
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
Also uses `new_current_thread` instead of `new_multi_thread`, and does some basic logic refactoring.