### PR TITLE
Stream multiplexing compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,6 +1919,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2110,6 +2111,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,8 +92,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -503,11 +515,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "ezsockets"
 version = "0.7.0"
 source = "git+https://github.com/gcpreston/ezsockets.git?branch=swb-reconnect-token#507fca970378b340c8b90df7144b1aef605d6461"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-trait",
  "atomic_enum",
  "base64 0.21.7",
@@ -1244,6 +1277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1945,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "swb"
 version = "0.2.1"
 dependencies = [
+ "async-channel 2.5.0",
  "async-trait",
  "base64 0.22.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tracing-subscriber = {version = "0.3.19", features = ["env-filter"] }
 ctrlc = "3.4.7"
 self_update = { version = "0.42.0", features = ["archive-tar", "archive-zip", "compression-flate2"] }
 tokio-stream = "0.1.17"
+async-channel = "2.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ tracing = "0.1.41"
 tracing-subscriber = {version = "0.3.19", features = ["env-filter"] }
 ctrlc = "3.4.7"
 self_update = { version = "0.42.0", features = ["archive-tar", "archive-zip", "compression-flate2"] }
+tokio-stream = "0.1.17"

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -96,20 +96,6 @@ fn create_packet(stream_id: u32, data: Vec<Vec<u8>>) -> Bytes {
     Bytes::from(packet)
 }
 
-fn decode_packet(bytes: Bytes) -> (u32, u32, Vec<u8>) {
-    let stream_id_bytes = bytes.slice(0..4);
-    let stream_id_vec = stream_id_bytes.to_vec();
-    let stream_id = u32::from_le_bytes(stream_id_vec.try_into().unwrap());
-
-    let size_bytes = bytes.slice(4..8);
-    let size_vec = size_bytes.to_vec();
-    let size = u32::from_le_bytes(size_vec.try_into().unwrap());
-
-    let data = bytes.slice(8..).to_vec();
-
-    (stream_id, size, data)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,18 +120,5 @@ mod tests {
         assert_eq!(stream_id_vec, vec![57, 48, 0, 0]);
         assert_eq!(size_vec, vec![10, 0, 0, 0]);
         assert_eq!(data_vec, vec![255, 60, 75, 0, 1, 127, 205, 15, 99, 191]);
-    }
-
-    #[test]
-    fn decode_packet_reads_header_and_data() {
-        let data_1: Vec<u8> = vec![255, 60, 75, 0, 1, 127];
-        let data_2: Vec<u8> = vec![205, 15, 99, 191];
-        let data: Vec<Vec<u8>> = vec![data_1, data_2];
-        let packet = create_packet(12345, data);
-        let result = decode_packet(packet);
-
-        assert_eq!(result.0, 12345);
-        assert_eq!(result.1, 10);
-        assert_eq!(result.2, vec![255, 60, 75, 0, 1, 127, 205, 15, 99, 191]);
     }
 }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,0 +1,41 @@
+use tokio_stream::StreamMap;
+use futures::stream::StreamExt;
+use ezsockets::Bytes;
+
+use crate::{dolphin_connection::{ConnectionEvent, DolphinConnection}, spectator_mode_client::{SpectatorModeClient, WSError}};
+
+pub fn merge_slippi_streams(slippi_conns: Vec<&DolphinConnection>, sm_client: SpectatorModeClient) -> impl Future<Output = Result<(), WSError>> {
+    let mut map = StreamMap::new();
+    let mut k = 0;
+
+    for slippi_conn in slippi_conns {
+        let slippi_stream = slippi_conn.event_stream();
+        // futures::pin_mut!(slippi_stream);
+        map.insert(k, slippi_stream);
+        k += 1;
+    }
+
+    map.filter_map(async |(_k, v)| {
+        let mut data: Vec<Vec<u8>> = Vec::new();
+
+        let _: Vec<()> =
+            v.into_iter().map(|e| {
+                match e {
+                    ConnectionEvent::StartGame => tracing::info!("Received game start event."),
+                    ConnectionEvent::EndGame => tracing::info!("Received game end event."),
+                    ConnectionEvent::Disconnect => tracing::info!("Disconnected from Slippi."),
+                    ConnectionEvent::Message { payload } => {
+                        data.push(payload);
+                    },
+                    _ => ()
+                };
+            }).collect();
+
+        if data.len() > 0 {
+            let b = Bytes::from(data.into_iter().flatten().collect::<Vec<u8>>());
+            Some(Ok(b))
+        } else {
+            None
+        }
+  }).forward(sm_client)
+}

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -32,6 +32,12 @@ pub fn merge_slippi_streams(slippi_conns: Vec<&DolphinConnection>) -> impl Strea
  * - 8 bytes: +100%
  * - 80 bytes: +10%
  * - 800 bytes: +1%
+ *
+ * TODO: I'm not sure if the data size is actually needed. This isn't a
+ * raw socket we are reading a fixed number of bytes from, it is a WebSocket
+ * connection which already abstracts byte size to create messages.
+ * However, if we want to send data for multiple streams in one message,
+ * byte size would be required.
  */
 
 pub fn forward_slippi_data(stream: impl Stream<Item = (u32, Vec<ConnectionEvent>)>, sm_client: SpectatorModeClient) -> impl Future<Output = Result<(), WSError>> {
@@ -64,18 +70,75 @@ pub fn forward_slippi_data(stream: impl Stream<Item = (u32, Vec<ConnectionEvent>
 }
 
 // https://stackoverflow.com/a/72631195
-fn convert(data: &[u32; 2]) -> [u8; 8] {
+fn create_header(data: &[u32; 2]) -> [u8; 8] {
     let mut res = [0; 8];
     for i in 0..2 {
-        res[2*i..][..2].copy_from_slice(&data[i].to_le_bytes());
+        res[4*i..][..4].copy_from_slice(&data[i].to_le_bytes());
     }
     res
 }
 
 fn create_packet(stream_id: u32, data: Vec<Vec<u8>>) -> Bytes {
-    let header = [stream_id, data.len() as u32];
-    let mut packet: Vec<u8> = convert(&header).into();
+    // TODO: Could this be more efficient by using BytesMut?
+    //   Think this would have to depend on the bytes package, and the packet sizes
+    //   would have to be known beforehand.
     let mut flat_data: Vec<u8> = data.into_iter().flatten().collect();
+    let header = [stream_id, flat_data.len() as u32];
+    let mut packet: Vec<u8> = create_header(&header).into();
     packet.append(&mut flat_data);
     Bytes::from(packet)
+}
+
+fn decode_packet(bytes: Bytes) -> (u32, u32, Vec<u8>) {
+    let stream_id_bytes = bytes.slice(0..4);
+    let stream_id_vec = stream_id_bytes.to_vec();
+    let stream_id = u32::from_le_bytes(stream_id_vec.try_into().unwrap());
+
+    let size_bytes = bytes.slice(4..8);
+    let size_vec = size_bytes.to_vec();
+    let size = u32::from_le_bytes(size_vec.try_into().unwrap());
+
+    let data = bytes.slice(8..).to_vec();
+
+    (stream_id, size, data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_header_generates_valid_header() {
+        let result = create_header(&[257, 10_000_000]);
+        assert_eq!(result, [1, 1, 0, 0, 128, 150, 152, 0]);
+    }
+
+    #[test]
+    fn create_packet_generates_valid_packet() {
+        let data_1: Vec<u8> = vec![255, 60, 75, 0, 1, 127];
+        let data_2: Vec<u8> = vec![205, 15, 99, 191];
+        let data: Vec<Vec<u8>> = vec![data_1, data_2];
+        let result = create_packet(12345, data);
+
+        let stream_id_vec = result.slice(0..4).to_vec();
+        let size_vec = result.slice(4..8).to_vec();
+        let data_vec = result.slice(8..).to_vec();
+
+        assert_eq!(stream_id_vec, vec![57, 48, 0, 0]);
+        assert_eq!(size_vec, vec![10, 0, 0, 0]);
+        assert_eq!(data_vec, vec![255, 60, 75, 0, 1, 127, 205, 15, 99, 191]);
+    }
+
+    #[test]
+    fn decode_packet_reads_header_and_data() {
+        let data_1: Vec<u8> = vec![255, 60, 75, 0, 1, 127];
+        let data_2: Vec<u8> = vec![205, 15, 99, 191];
+        let data: Vec<Vec<u8>> = vec![data_1, data_2];
+        let packet = create_packet(12345, data);
+        let result = decode_packet(packet);
+
+        assert_eq!(result.0, 12345);
+        assert_eq!(result.1, 10);
+        assert_eq!(result.2, vec![255, 60, 75, 0, 1, 127, 205, 15, 99, 191]);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn connect_and_forward_packets_until_completion(source: &str, dest: &str) {
     // Initiate connections.
     let (slippi_conn, mut slippi_interrupt) = connect_to_slippi(source).await;
-    let (sm_client, sm_client_future, bridge_info) = spectator_mode_client::initiate_connection(dest).await;
+    let (sm_client, sm_client_future, bridge_info) = spectator_mode_client::initiate_connection(dest, 1).await;
     let mut slippi_interrupts = vec![&mut slippi_interrupt];
 
     // Set up the futures to await.

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,12 +80,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn connect_and_forward_packets_until_completion(source: &str, dest: &str) {
     // Initiate connections.
     let (slippi_conn, mut slippi_interrupt) = connect_to_slippi(source).await;
-    let (sm_client, sm_client_future) = spectator_mode_client::initiate_connection(dest).await;
+    let (sm_client, sm_client_future, bridge_info) = spectator_mode_client::initiate_connection(dest).await;
     let mut slippi_interrupts = vec![&mut slippi_interrupt];
 
     // Set up the futures to await.
     // Each individual future will attempt to gracefully disconnect the other.
-    let merged_stream = connection_manager::merge_slippi_streams(vec![&slippi_conn]);
+    let merged_stream = connection_manager::merge_slippi_streams(vec![&slippi_conn], bridge_info.stream_ids).unwrap();
     let dolphin_to_sm = connection_manager::forward_slippi_data(merged_stream, sm_client);
     let extended_sm_client_future = async {
         let result = sm_client_future.await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::{dolphin_connection::DolphinConnection, spectator_mode_client::Specta
 
 mod dolphin_connection;
 mod spectator_mode_client;
+mod connection_manager;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,13 @@
 use std::{error::Error, net::SocketAddr, str::FromStr};
 
 use clap::Parser;
-use dolphin_connection::ConnectionEvent;
-use ezsockets::Bytes;
-use futures::{channel::mpsc::channel, future, StreamExt};
+use futures::{channel::mpsc::channel, future};
 use rusty_enet as enet;
 use spectator_mode_client::WSError;
 use tracing::Level;
 use self_update::cargo_crate_version;
 
-use crate::{dolphin_connection::DolphinConnection, spectator_mode_client::SpectatorModeClient};
+use crate::{dolphin_connection::DolphinConnection};
 
 mod dolphin_connection;
 mod spectator_mode_client;
@@ -83,13 +81,15 @@ async fn connect_and_forward_packets_until_completion(source: &str, dest: &str) 
     // Initiate connections.
     let (slippi_conn, mut slippi_interrupt) = connect_to_slippi(source).await;
     let (sm_client, sm_client_future) = spectator_mode_client::initiate_connection(dest).await;
+    let mut slippi_interrupts = vec![&mut slippi_interrupt];
 
     // Set up the futures to await.
     // Each individual future will attempt to gracefully disconnect the other.
-    let dolphin_to_sm = forward_slippi_data(&slippi_conn, sm_client);
+    let merged_stream = connection_manager::merge_slippi_streams(vec![&slippi_conn]);
+    let dolphin_to_sm = connection_manager::forward_slippi_data(merged_stream, sm_client);
     let extended_sm_client_future = async {
         let result = sm_client_future.await;
-        slippi_interrupt();
+        slippi_interrupts.iter_mut().for_each(|interrupt| interrupt());
         result
     };
 
@@ -128,40 +128,6 @@ async fn connect_to_slippi(source_addr: &str) -> (DolphinConnection, impl FnMut(
     .unwrap();
 
     (conn, interruptor_to_return)
-}
-
-
-fn forward_slippi_data(slippi_conn: &DolphinConnection, sm_client: SpectatorModeClient) -> impl Future<Output = Result<(), WSError>> {
-    slippi_conn
-        .event_stream()
-        .filter_map(async |es| {
-            let mut data: Vec<Vec<u8>> = Vec::new();
-
-            let _: Vec<()> =
-                es.into_iter().map(|e| {
-                    // Side-effects
-                    // ConnectionEvent::Connected will not reach the stream because
-                    // it is awaited before initiating the SpectatorMode connection.
-                    match e {
-                        ConnectionEvent::StartGame => tracing::info!("Received game start event."),
-                        ConnectionEvent::EndGame => tracing::info!("Received game end event."),
-                        ConnectionEvent::Disconnect => tracing::info!("Disconnected from Slippi."),
-                        ConnectionEvent::Message { payload } => {
-                            data.push(payload);
-                        },
-                        _ => ()
-                    };
-                }).collect();
-
-            // Return
-            if data.len() > 0 {
-                let b = Bytes::from(data.into_iter().flatten().collect::<Vec<u8>>());
-                Some(Ok(b))
-            } else {
-                None
-            }
-        })
-        .forward(sm_client)
 }
 
 fn log_forward_result(result: Result<(), WSError>) {

--- a/src/spectator_mode_client.rs
+++ b/src/spectator_mode_client.rs
@@ -107,12 +107,12 @@ impl Sink<Bytes> for SpectatorModeClient {
     }
 }
 
-pub async fn initiate_connection(address: &str) -> (SpectatorModeClient, impl std::future::Future<Output = Result<(), Error>>, BridgeInfo) {
+pub async fn initiate_connection(address: &str, stream_count: u32) -> (SpectatorModeClient, impl std::future::Future<Output = Result<(), Error>>, BridgeInfo) {
     tracing::info!("Connecting to SpectatorMode...");
     let url = Url::parse(address).unwrap();
     let mut socket_config = SocketConfig::default();
     socket_config.timeout = Duration::from_secs(15);
-    let config = ClientConfig::new(url).socket_config(socket_config).max_reconnect_attempts(3);
+    let config = ClientConfig::new(url).socket_config(socket_config).max_reconnect_attempts(3).query_parameter("stream_count", stream_count.to_string().as_str());
     let (connected_sender, connected_receiver) = async_channel::unbounded();
     let (sm_handle, future) = ezsockets::connect(|handle| MyClient { handle, connected_sender, initially_connected: false }, config).await;
 

--- a/src/spectator_mode_client.rs
+++ b/src/spectator_mode_client.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 use std::time::Duration;
 use thiserror::Error;
 use url::Url;
+use async_channel;
 
 #[derive(Error, Debug)]
 pub enum WSError {
@@ -23,6 +24,7 @@ pub enum WSError {
 
 pub struct MyClient {
     handle: ezsockets::Client<Self>,
+    connected_sender: async_channel::Sender<BridgeInfo>
 }
 
 pub struct SpectatorModeClient {
@@ -33,9 +35,10 @@ pub enum Call {
     GameData(Bytes),
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct BridgeInfo {
     pub bridge_id: String,
+    pub stream_ids: Vec<u32>
 }
 
 #[async_trait]
@@ -44,10 +47,7 @@ impl ezsockets::ClientExt for MyClient {
 
     async fn on_text(&mut self, text: ezsockets::Utf8Bytes) -> Result<(), Error> {
         let bridge_info = serde_json::from_str::<BridgeInfo>(text.as_str())?;
-        tracing::info!(
-            "Connected to SpectatorMode with stream ID {}",
-            bridge_info.bridge_id
-        );
+        self.connected_sender.send(bridge_info).await?;
         Ok(())
     }
 
@@ -102,13 +102,21 @@ impl Sink<Bytes> for SpectatorModeClient {
     }
 }
 
-pub async fn initiate_connection(address: &str) -> (SpectatorModeClient, impl std::future::Future<Output = Result<(), Error>>) {
+pub async fn initiate_connection(address: &str) -> (SpectatorModeClient, impl std::future::Future<Output = Result<(), Error>>, BridgeInfo) {
     tracing::info!("Connecting to SpectatorMode...");
     let url = Url::parse(address).unwrap();
     let mut socket_config = SocketConfig::default();
     socket_config.timeout = Duration::from_secs(15);
     let config = ClientConfig::new(url).socket_config(socket_config).max_reconnect_attempts(3);
-    let (sm_handle, future) = ezsockets::connect(|handle| MyClient { handle }, config).await;
+    let (connected_sender, connected_receiver) = async_channel::unbounded();
+    let (sm_handle, future) = ezsockets::connect(|handle| MyClient { handle, connected_sender }, config).await;
 
-    (SpectatorModeClient { ws_client: sm_handle }, future)
+    let bridge_info = connected_receiver.recv().await.unwrap();
+     tracing::info!(
+        "Connected to SpectatorMode with bridge ID {} and stream IDs {:?}",
+        bridge_info.bridge_id,
+        bridge_info.stream_ids
+    );
+
+    (SpectatorModeClient { ws_client: sm_handle }, future, bridge_info)
 }


### PR DESCRIPTION
This PR enables swb to be compatible with the stream multiplexing features in SpectatorMode (https://github.com/gcpreston/spectator_mode/pull/19). It does not add the ability to establish multiple connections at once yet, but it does receive and display assigned stream IDs, prefix packets with stream IDs in the appropriate way, and provide an API to request more streams from SpectatorMode.